### PR TITLE
Read status for messages

### DIFF
--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -57,6 +57,7 @@ const ActiveChat = ({
                 <Input
                   otherUser={conversation.otherUser}
                   conversationId={conversation.id || null}
+                  unreadMessages={conversation.unreadMessages || null}
                   user={user}
                   postMessage={postMessage}
                   updateReadMessages={updateReadMessages}

--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -24,6 +24,7 @@ const ActiveChat = ({
   conversations,
   activeConversation,
   postMessage,
+  updateReadMessages
 }) => {
   const classes = useStyles();
 
@@ -58,6 +59,7 @@ const ActiveChat = ({
                   conversationId={conversation.id || null}
                   user={user}
                   postMessage={postMessage}
+                  updateReadMessages={updateReadMessages}
                 />
               </>
             )}

--- a/client/src/components/ActiveChat/Input.js
+++ b/client/src/components/ActiveChat/Input.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const Input = ({ otherUser, conversationId, user, postMessage }) => {
+const Input = ({ otherUser, conversationId, user, postMessage, updateReadMessages }) => {
   const classes = useStyles();
   const [text, setText] = useState('');
 
@@ -38,6 +38,11 @@ const Input = ({ otherUser, conversationId, user, postMessage }) => {
     setText('');
   };
 
+  const handleFocus = (event) => {
+    event.preventDefault();
+    updateReadMessages(conversationId);
+  }
+
   return (
     <form className={classes.root} onSubmit={handleSubmit}>
       <FormControl fullWidth hiddenLabel>
@@ -48,6 +53,7 @@ const Input = ({ otherUser, conversationId, user, postMessage }) => {
           value={text}
           name="text"
           onChange={handleChange}
+          onFocus={handleFocus}
         />
       </FormControl>
     </form>

--- a/client/src/components/ActiveChat/Input.js
+++ b/client/src/components/ActiveChat/Input.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const Input = ({ otherUser, conversationId, user, postMessage, updateReadMessages }) => {
+const Input = ({ otherUser, conversationId, user, postMessage, updateReadMessages, unreadMessages }) => {
   const classes = useStyles();
   const [text, setText] = useState('');
 
@@ -40,7 +40,9 @@ const Input = ({ otherUser, conversationId, user, postMessage, updateReadMessage
 
   const handleFocus = (event) => {
     event.preventDefault();
-    updateReadMessages(conversationId);
+    if (unreadMessages) {
+      updateReadMessages(conversationId);
+    }
   }
 
   return (

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -5,9 +5,18 @@ import moment from 'moment';
 
 const Messages = (props) => {
   const { messages, otherUser, userId } = props;
-  var lastMessageId;
+
+  const findLastReadId = (messages) => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].wasRead && messages[i].senderId === userId) {
+        return messages[i].id;
+      }
+    }
+  }
+
+  let lastRead;
   if (messages.length > 0) {
-    lastMessageId = messages[messages.length - 1].id;
+    lastRead = findLastReadId(messages);
   }
 
   return (
@@ -21,7 +30,7 @@ const Messages = (props) => {
             time={time}
             message={message}
             otherUser={otherUser}
-            lastMessageId={lastMessageId}
+            lastRead={lastRead}
           />
         ) : (
           <OtherUserBubble

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 
 const Messages = (props) => {
   const { messages, otherUser, userId } = props;
+  const lastMessageId = messages[messages.length - 1].id;
 
   return (
     <Box>
@@ -12,7 +13,13 @@ const Messages = (props) => {
         const time = moment(message.createdAt).format('h:mm');
 
         return message.senderId === userId ? (
-          <SenderBubble key={message.id} text={message.text} time={time} />
+          <SenderBubble
+            key={message.id}
+            time={time}
+            message={message}
+            otherUser={otherUser}
+            lastMessageId={lastMessageId}
+          />
         ) : (
           <OtherUserBubble
             key={message.id}

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -5,7 +5,10 @@ import moment from 'moment';
 
 const Messages = (props) => {
   const { messages, otherUser, userId } = props;
-  const lastMessageId = messages[messages.length - 1].id;
+  var lastMessageId;
+  if (messages.length > 0) {
+    lastMessageId = messages[messages.length - 1].id;
+  }
 
   return (
     <Box>

--- a/client/src/components/ActiveChat/SenderBubble.js
+++ b/client/src/components/ActiveChat/SenderBubble.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Box, Typography } from '@material-ui/core';
+import { Box, Typography, Avatar } from '@material-ui/core';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -25,10 +25,15 @@ const useStyles = makeStyles(() => ({
     background: '#F4F6FA',
     borderRadius: '10px 10px 0 10px',
   },
+  profilePic: {
+    height: 22,
+    width: 22,
+  }
 }));
 
-const SenderBubble = ({ time, text }) => {
+const SenderBubble = ({ time, message, otherUser, lastMessageId }) => {
   const classes = useStyles();
+  const { id, text, wasRead } = message;
 
   return (
     <Box className={classes.root}>
@@ -36,6 +41,9 @@ const SenderBubble = ({ time, text }) => {
       <Box className={classes.bubble}>
         <Typography className={classes.text}>{text}</Typography>
       </Box>
+      {wasRead && id === lastMessageId &&
+        <Avatar alt={otherUser.username} src={otherUser.photoUrl} className={classes.profilePic}></Avatar>
+      }
     </Box>
   );
 };

--- a/client/src/components/ActiveChat/SenderBubble.js
+++ b/client/src/components/ActiveChat/SenderBubble.js
@@ -31,7 +31,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const SenderBubble = ({ time, message, otherUser, lastMessageId }) => {
+const SenderBubble = ({ time, message, otherUser, lastRead }) => {
   const classes = useStyles();
   const { id, text, wasRead } = message;
 
@@ -41,7 +41,7 @@ const SenderBubble = ({ time, message, otherUser, lastMessageId }) => {
       <Box className={classes.bubble}>
         <Typography className={classes.text}>{text}</Typography>
       </Box>
-      {wasRead && id === lastMessageId &&
+      {wasRead && id === lastRead &&
         <Avatar alt={otherUser.username} src={otherUser.photoUrl} className={classes.profilePic}></Avatar>
       }
     </Box>

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -94,6 +94,7 @@ const Home = ({ user, logout }) => {
       conversations.forEach((convo) => {
         if (convo.id === conversationId) {
           convo.messages = messages;
+          convo.unreadMessages = 0;
         }
       });
       setConversations((prev) =>
@@ -114,6 +115,7 @@ const Home = ({ user, logout }) => {
           convo.messages.push(message);
           convo.latestMessageText = message.text;
           convo.id = message.conversationId;
+          convo.unreadMessages += 1;
         }
       });
       setConversations((prev) =>
@@ -145,6 +147,7 @@ const Home = ({ user, logout }) => {
         if (convo.id === message.conversationId) {
           convo.messages.push(message);
           convo.latestMessageText = message.text;
+          convo.unreadMessages += 1;
         }
       });
       setConversations((prev) =>

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -73,6 +73,28 @@ const Home = ({ user, logout }) => {
     }
   };
 
+  const updateReadMessages = async (conversationId) => {
+    try {
+      const { data } = await axios.put('/api/messages', {conversationId});
+
+      conversations.forEach((convo) => {
+        if (convo.id === conversationId) {
+          convo.messages = data.messages
+        }
+      });
+
+      setConversations((prev) =>
+        prev.map((convo) => {
+          const convoCopy = { ...convo };
+          convoCopy.messages = [ ...convoCopy.messages ];
+          return convoCopy;
+        })
+      );
+    } catch(error) {
+      console.log(error)
+    }
+  }
+
   const addNewConvo = useCallback(
     (recipientId, message) => {
       conversations.forEach((convo) => {
@@ -223,6 +245,7 @@ const Home = ({ user, logout }) => {
           conversations={conversations}
           user={user}
           postMessage={postMessage}
+          updateReadMessages={updateReadMessages}
         />
       </Grid>
     </>

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -91,43 +91,37 @@ const Home = ({ user, logout }) => {
   const markReadMessages = useCallback(
     (data) => {
       const { conversationId, messages } = data;
-      conversations.forEach((convo) => {
-        if (convo.id === conversationId) {
-          convo.messages = messages;
-          convo.unreadMessages = 0;
-        }
-      });
       setConversations((prev) =>
         prev.map((convo) => {
-          const convoCopy = { ...convo };
-          convoCopy.messages = [ ...convoCopy.messages ];
-          return convoCopy;
+          if (convo.id === conversationId) {
+            const convoCopy = { ...convo };
+            convoCopy.unreadMessages = 0;
+            convoCopy.messages = messages;
+            return convoCopy;
+          } else {
+            return convo;
+          }
         })
       );
-    },
-    [setConversations, conversations]
-  );
+    }, []);
 
   const addNewConvo = useCallback(
     (recipientId, message) => {
-      conversations.forEach((convo) => {
-        if (convo.otherUser.id === recipientId) {
-          convo.messages.push(message);
-          convo.latestMessageText = message.text;
-          convo.id = message.conversationId;
-          convo.unreadMessages += 1;
-        }
-      });
       setConversations((prev) =>
         prev.map((convo) => {
-          const convoCopy = { ...convo };
-          convoCopy.messages = [ ...convoCopy.messages ];
-          return convoCopy;
+          if (convo.otherUser.id === recipientId) {
+            const convoCopy = { ...convo };
+            convoCopy.latestMessageText = message.text;
+            convoCopy.id = message.conversationId;
+            convoCopy.unreadMessages += 1;
+            convoCopy.messages = [ ...convoCopy.messages, message ];
+            return convoCopy;
+          } else {
+            return convo;
+          }
         })
       );
-    },
-    [setConversations, conversations]
-  );
+    }, []);
 
   const addMessageToConversation = useCallback(
     (data) => {
@@ -143,23 +137,20 @@ const Home = ({ user, logout }) => {
         setConversations((prev) => [newConvo, ...prev]);
       }
 
-      conversations.forEach((convo) => {
-        if (convo.id === message.conversationId) {
-          convo.messages.push(message);
-          convo.latestMessageText = message.text;
-          convo.unreadMessages += 1;
-        }
-      });
       setConversations((prev) =>
         prev.map((convo) => {
-          const convoCopy = { ...convo };
-          convoCopy.messages = [ ...convoCopy.messages ];
-          return convoCopy;
+          if (convo.id === message.conversationId) {
+            const convoCopy = { ...convo };
+            convoCopy.latestMessageText = message.text;
+            convoCopy.unreadMessages += 1;
+            convoCopy.messages = [ ...convoCopy.messages, message ];
+            return convoCopy;
+          } else {
+            return convo;
+          }
         })
       );
-    },
-    [setConversations, conversations]
-  );
+    }, []);
 
   const setActiveChat = (username) => {
     setActiveConversation(username);

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Chat = ({ conversation, setActiveChat }) => {
+const Chat = ({ conversation, setActiveChat, user }) => {
   const classes = useStyles();
   const { otherUser } = conversation;
 
@@ -33,7 +33,7 @@ const Chat = ({ conversation, setActiveChat }) => {
         online={otherUser.online}
         sidebar={true}
       />
-      <ChatContent conversation={conversation} />
+      <ChatContent conversation={conversation} user={user}/>
     </Box>
   );
 };

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -18,12 +18,37 @@ const useStyles = makeStyles((theme) => ({
     color: "#9CADC8",
     letterSpacing: -0.17,
   },
+  previewUnreadText: {
+    fontSize: 12,
+    color: "black",
+    letterSpacing: -0.17,
+    fontWeight: "bold",
+  },
+  unreadCount: {
+    height: 22,
+    width: 22,
+    fontSize: 14,
+    color: "white",
+    letterSpacing: -0.17,
+    fontWeight: "bold",
+    backgroundColor: " #3A8DFF",
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 14
+  },
+  notification: {
+    display: "flex",
+    alignItems: "center",
+    marginRight: 20
+  }
 }));
 
-const ChatContent = ({ conversation }) => {
+const ChatContent = ({ conversation, user }) => {
   const classes = useStyles();
 
-  const { otherUser } = conversation;
+  const { otherUser, messages, unreadMessages } = conversation;
   const latestMessageText = conversation.id && conversation.latestMessageText;
 
   return (
@@ -32,10 +57,23 @@ const ChatContent = ({ conversation }) => {
         <Typography className={classes.username}>
           {otherUser.username}
         </Typography>
-        <Typography className={classes.previewText}>
+        <Typography
+          className={
+            unreadMessages > 0 && messages[messages.length - 1].senderId !== user.id
+            ? classes.previewUnreadText
+            : classes.previewText
+          }
+        >
           {latestMessageText}
         </Typography>
       </Box>
+      {unreadMessages > 0 && messages[messages.length - 1].senderId !== user.id &&
+        <Box className={classes.notification}>
+          <Typography className={classes.unreadCount}>
+            {unreadMessages}
+          </Typography>
+        </Box>
+      }
     </Box>
   );
 };

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -39,6 +39,14 @@ const ChatContent = ({ conversation, user }) => {
   const { otherUser, messages, unreadMessages } = conversation;
   const latestMessageText = conversation.id && conversation.latestMessageText;
 
+  const getLastSenderId = (messages) => {
+    if (messages.length) {
+      return messages[messages.length - 1].senderId;
+    }
+  }
+
+  let lastSender = getLastSenderId(messages);
+
   return (
     <Box className={classes.root}>
       <Box>
@@ -47,7 +55,7 @@ const ChatContent = ({ conversation, user }) => {
         </Typography>
         <Typography
           className={
-            unreadMessages > 0 && messages[messages.length - 1].senderId !== user.id
+            unreadMessages > 0 && lastSender !== user.id
             ? classes.previewUnreadText
             : classes.previewText
           }
@@ -55,12 +63,14 @@ const ChatContent = ({ conversation, user }) => {
           {latestMessageText}
         </Typography>
       </Box>
-      <Badge
+      {unreadMessages > 0 && lastSender !== user.id &&
+        <Badge
         badgeContent={unreadMessages}
         color='primary'
         classes={{badge: classes.badge}}
-      >
-      </Badge>
+        >
+        </Badge>
+      }
     </Box>
   );
 };

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Typography } from "@material-ui/core";
+import { Box, Typography, Badge } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme) => ({
@@ -24,25 +24,13 @@ const useStyles = makeStyles((theme) => ({
     letterSpacing: -0.17,
     fontWeight: "bold",
   },
-  unreadCount: {
-    height: 22,
-    width: 22,
+  badge: {
     fontSize: 14,
-    color: "white",
     letterSpacing: -0.17,
     fontWeight: "bold",
-    backgroundColor: " #3A8DFF",
-    borderRadius: "50%",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 14
+    marginRight: 40,
+    top: "50%"
   },
-  notification: {
-    display: "flex",
-    alignItems: "center",
-    marginRight: 20
-  }
 }));
 
 const ChatContent = ({ conversation, user }) => {
@@ -67,13 +55,12 @@ const ChatContent = ({ conversation, user }) => {
           {latestMessageText}
         </Typography>
       </Box>
-      {unreadMessages > 0 && messages[messages.length - 1].senderId !== user.id &&
-        <Box className={classes.notification}>
-          <Typography className={classes.unreadCount}>
-            {unreadMessages}
-          </Typography>
-        </Box>
-      }
+      <Badge
+        badgeContent={unreadMessages}
+        color='primary'
+        classes={{badge: classes.badge}}
+      >
+      </Badge>
     </Box>
   );
 };

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -42,6 +42,7 @@ const Sidebar = ({
               conversation={conversation}
               key={conversation.otherUser.username}
               setActiveChat={setActiveChat}
+              user={user}
             />
           );
         })}

--- a/server/bin/www
+++ b/server/bin/www
@@ -47,6 +47,10 @@ io.on("connection", (socket) => {
     });
   });
 
+  socket.on("read-messages", (data) => {
+    socket.broadcast.emit("read-messages", data);
+  });
+
   socket.on("logout", (id) => {
     if (onlineUsers.includes(id)) {
       userIndex = onlineUsers.indexOf(id);

--- a/server/db/models/message.js
+++ b/server/db/models/message.js
@@ -10,6 +10,11 @@ const Message = db.define("message", {
     type: Sequelize.INTEGER,
     allowNull: false,
   },
+  wasRead: {
+    type: Sequelize.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  },
 });
 
 module.exports = Message;

--- a/server/db/seed.js
+++ b/server/db/seed.js
@@ -32,11 +32,13 @@ async function seed() {
     conversationId: santaigoConvo.id,
     senderId: santiago.id,
     text: "Where are you from?",
+    wasRead: true,
   });
   await Message.create({
     conversationId: santaigoConvo.id,
     senderId: thomas.id,
     text: "I'm from New York",
+    wasRead: true,
   });
   await Message.create({
     conversationId: santaigoConvo.id,

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -70,6 +70,12 @@ router.get("/", async (req, res, next) => {
       // set properties for notification count and latest message preview
       convoJSON.messages.reverse();
       convoJSON.latestMessageText = convoJSON.messages[convoJSON.messages.length - 1].text;
+      convoJSON.unreadMessages = await Message.count({
+        where: {
+          conversationId: convoJSON.id,
+          wasRead: false,
+        }
+      });
       conversations[i] = convoJSON;
     }
 

--- a/server/routes/api/messages.js
+++ b/server/routes/api/messages.js
@@ -52,6 +52,20 @@ router.put('/', async (req, res, next) => {
     const readerId = req.user.id;
     const { conversationId } = req.body;
 
+    const conversation = await Conversation.findOne({
+      where: {
+        id: conversationId,
+        [Op.or]: {
+          user1Id: readerId,
+          user2Id: readerId,
+        }
+      }
+    })
+
+    if (!conversation) {
+      return res.sendStatus(403);
+    }
+
     await Message.update({ wasRead: true}, {
       where: {
         conversationId: {
@@ -70,7 +84,7 @@ router.put('/', async (req, res, next) => {
       order: [["createdAt", "ASC"]]
     });
 
-    res.json({ messages } )
+    res.json({ messages })
   } catch (error) {
     next(error);
   }

--- a/server/routes/api/messages.js
+++ b/server/routes/api/messages.js
@@ -1,6 +1,7 @@
 const router = require("express").Router();
 const { Conversation, Message } = require("../../db/models");
 const onlineUsers = require("../../onlineUsers");
+const { Op } = require("sequelize");
 
 // expects {recipientId, text, conversationId } in body (conversationId will be null if no conversation exists yet)
 router.post("/", async (req, res, next) => {
@@ -42,5 +43,37 @@ router.post("/", async (req, res, next) => {
     next(error);
   }
 });
+
+router.put('/', async (req, res, next) => {
+  try {
+    if (!req.user) {
+      return res.sendStatus(401);
+    }
+    const readerId = req.user.id;
+    const { conversationId } = req.body;
+
+    await Message.update({ wasRead: true}, {
+      where: {
+        conversationId: {
+          [Op.eq]: conversationId
+        },
+        senderId: {
+          [Op.ne]: readerId
+        }
+      }
+    });
+
+    const messages = await Message.findAll({
+      where: {
+        conversationId: conversationId
+      },
+      order: [["createdAt", "ASC"]]
+    });
+
+    res.json({ messages } )
+  } catch (error) {
+    next(error);
+  }
+})
 
 module.exports = router;


### PR DESCRIPTION
## Description
1. Updated frontend to show when the most recent message has been read by recipient and how many unread messages the user has in the conversation.

2. Updated the backend to include `wasRead` property on the `Message` model to track and persist when a message was read by the recipient. Additionally, added `unreadMessages` property to return object when querying conversations to track number of unread messages per conversation.

3. The first way to store the read status was the approach I took: adding a field to the `Message` model that tracked each message's read status. The benefit of this method is that you are able to track an individual message's status with one drawback being that when the recipient views the conversation, you have to update all the messages' status to be true, which takes more time than just updating the whole conversation's status. That brings me to the second idea of tracking the entire conversation's read status instead of an individual message. Given that when you view a conversation all the messages read status turns to be true, you could easily just have that as field on the `Conversation` model instead. This however makes keeping track of the number of unread messages more challenging as you cannot just count the number of unread messages. Additional logic would need to be built to increment/decrement the number of unread messages per conversation and another field would need to store this data.

Link: https://github.com/Mitch311G/95983d/issues/3#issue-1169871867
![Screen Shot 2022-03-17 at 6 40 18 PM](https://user-images.githubusercontent.com/91696259/158915877-308faf5d-2b46-4a84-b466-4926d2236412.jpg)



## Notes on your approach and thought process

I knew that we needed to persist the status of each message (was it read or not read) and thus a change to the `Message` model was needed to hold this data. After making adjustments to the backend, the UI needed to conditionally render if the message they sent had been read.  I created a put request handler to update the conversation's message's `wasRead` status to true and added a socket emitter to update in live-time. To find the total number of unread messages in a conversation, I used an aggregation function `.count()` with Sequelize and added the property to the conversation return object. This also needed to be conditionally rendered and so logic was built into the frontend that displayed when new messages were in the chat and not yet read.

## Further comments (optional)
To mark messages as read, you need to click on the `Input` bar of the conversation, where the `onFocus` event listener runs the functions to update the database and emit a socket message.